### PR TITLE
Build ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - uses: actions/setup-python@v5
@@ -50,5 +50,5 @@ jobs:
     - name: Archive binary
       uses: actions/upload-artifact@v4
       with:
-        name: uf2
+        name: BroncoDeployment.uf2
         path: build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,13 +16,16 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+        cache: 'pip'
     - name: Install Arduino CLI
       uses: arduino/setup-arduino-cli@v2
       with:
         version: "1.0.1"
     - name: Install Arduino CLI CMake Wrapper
-      run: |
-        pip3 install arduino-cli-cmake-wrapper
+      run: pip install arduino-cli-cmake-wrapper
       shell: bash
     - name: Configure Arduino CLI and Install RP2040 Core
       run: |
@@ -31,10 +34,13 @@ jobs:
         arduino-cli core install rp2040:rp2040
       shell: bash
     - name: Install Arduino Libraries
-      run: arduino-cli lib install Time RadioHead
+      run: |
+        arduino-cli lib install \
+          RadioHead \
+          Time
       shell: bash
     - name: Install F' Requirements
-      run: pip3 install -r fprime/requirements.txt
+      run: pip install -r fprime/requirements.txt
       shell: bash
     - name: Build binary
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,43 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - devel
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Install Arduino CLI
+      uses: arduino/setup-arduino-cli@v2
+      with:
+        version: "1.0.1"
+    - name: Install Arduino CLI CMake Wrapper
+      run: |
+        pip3 install arduino-cli-cmake-wrapper
+      shell: bash
+    - name: Configure Arduino CLI and Install RP2040 Core
+      run: |
+        arduino-cli config init
+        arduino-cli config add board_manager.additional_urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+        arduino-cli core install rp2040:rp2040
+      shell: bash
+    - name: Install Arduino Libraries
+      run: arduino-cli lib install Time RadioHead
+      shell: bash
+    - name: Install F' Requirements
+      run: pip3 install -r fprime/requirements.txt
+      shell: bash
+    - name: Build binary
+      run: |
+        fprime-util generate rpipico
+        fprime-util build rpipico
+      shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,3 +41,8 @@ jobs:
         fprime-util generate rpipico
         fprime-util build rpipico
       shell: bash
+    - name: Archive binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: uf2
+        path: build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # fprime-proves F' project
+[![build](https://github.com/proveskit/fprime-proves/actions/workflows/build.yaml/badge.svg)](https://github.com/proveskit/fprime-proves/actions/workflows/build.yaml)
+
 Valid for F' 3.4.3
 
 ## Building and Running the Deployment


### PR DESCRIPTION
This PR adds an automated build pipeline that publishes the UF2.
<img width="1418" alt="Screenshot 2024-08-14 at 23 05 24" src="https://github.com/user-attachments/assets/46f4e6ec-01f0-499a-a041-1725ebd72951">

We should consider adding pipelines that publish the GDS binary for each major OS.

As I mentioned in [the issue](https://github.com/proveskit/fprime-proves/issues/5#issuecomment-2290475765), I had intended to use the composite action from the fprime-community builder but I quickly realized that I would be unable to specify the `rpipico` build target (unless I'm missing something?). It's OK though, replacing the composite action only adds a single step.

Satisfies #5.