### PR TITLE
Use composite action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,4 +52,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: BroncoDeploymentAppDictionary.xml
-        path: build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentAppDictionary.xml
+        path: build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentTopologyAppDictionary.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,3 +52,8 @@ jobs:
       with:
         name: BroncoDeployment.uf2
         path: build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2
+    - name: Archive app dictionary
+      uses: actions/upload-artifact@v4
+      with:
+        name: BroncoDeploymentAppDictionary.xml
+        path: build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentAppDictionary.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,14 +39,10 @@ jobs:
           RadioHead \
           Time
       shell: bash
-    - name: Install F' Requirements
-      run: pip install -r fprime/requirements.txt
-      shell: bash
-    - name: Build binary
-      run: |
-        fprime-util generate rpipico
-        fprime-util build rpipico
-      shell: bash
+    - uses: fprime-community/project-builder@main
+      with:
+        build_location: BroncoDeployment
+        target_platform: rpipico
     - name: Archive binary
       uses: actions/upload-artifact@v4
       with:

--- a/Components/Radio/RFM69/CMakeLists.txt
+++ b/Components/Radio/RFM69/CMakeLists.txt
@@ -14,14 +14,6 @@ set(SOURCE_FILES
 # Uncomment and add any modules that this component depends on, else
 # they might not be available when cmake tries to build this component.
 
-string(FIND "${FPRIME_TOOLCHAIN_NAME}" "teensy" index)
-if (NOT index EQUAL -1)
-  set(MOD_DEPS
-    RadioHead
-  )
-  target_use_arduino_libraries("SPI")
-else()
-  target_use_arduino_libraries("SPI" "RH_RF69")
-endif()
+target_use_arduino_libraries("SPI" "RH_RF69")
 
 register_fprime_module()

--- a/Components/Radio/RFM69/RFM69.cpp
+++ b/Components/Radio/RFM69/RFM69.cpp
@@ -16,19 +16,10 @@ namespace Radio {
 
 RFM69::RFM69(const char* const compName)
     : RFM69ComponentBase(compName),
-#if defined(_BOARD_TEENSY41)
-      rfm69(RFM69_CS, RFM69_INT, hardware_spi1),
-#else
       rfm69(RFM69_CS, RFM69_INT),
-#endif
       radio_state(Fw::On::OFF),
       pkt_rx_count(0),
       pkt_tx_count(0) {
-
-#if defined(_BOARD_TEENSY32)
-    SPI.setSCK(RFM69_SCK);
-#endif
-
 }
 
 RFM69::~RFM69() {}

--- a/Components/Radio/RFM69/RFM69.hpp
+++ b/Components/Radio/RFM69/RFM69.hpp
@@ -12,10 +12,6 @@
 #include "RFM69Pinout.hpp"
 #include <FprimeArduino.hpp>
 
-#if defined(_BOARD_TEENSY41)
-#include <RHHardwareSPI1.h>
-#endif
-
 namespace Radio {
 
   class RFM69 :

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Valid for F' 3.4.3
 `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$VIRTUAL_ENV/bin sh`
 1. Install the arduino-cli-wrapper `pip install arduino-cli-cmake-wrapper`
 1. Install the RP2040 board
-  ```sh
-  arduino-cli config init
-  arduino-cli config add board_manager.additional_urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
-  arduino-cli core install rp2040:rp2040
-  ```
+    ```sh
+    arduino-cli config init
+    arduino-cli config add board_manager.additional_urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+    arduino-cli core install rp2040:rp2040
+    ```
 1. Install additional arduino-cli dependencies:
-  ```sh
-  arduino-cli lib install Time
-  arduino-cli lib install RadioHead
-  ```
+    ```sh
+    arduino-cli lib install Time
+    arduino-cli lib install RadioHead
+    ```
 
 ### Deploy onto the RP2040
 1. Build the binary `fprime-util generate rpipico && fprime-util build rpipico -j20`

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Valid for F' 3.4.3
 `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$VIRTUAL_ENV/bin sh`
 1. Install the arduino-cli-wrapper `pip install arduino-cli-cmake-wrapper`
 1. Install the RP2040 board
-```sh
-arduino-cli config init
-arduino-cli config add board_manager.additional_urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
-arduino-cli core install rp2040:rp2040
-```
+  ```sh
+  arduino-cli config init
+  arduino-cli config add board_manager.additional_urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+  arduino-cli core install rp2040:rp2040
+  ```
 1. Install additional arduino-cli dependencies:
-```sh
-arduino-cli lib install Time
-arduino-cli lib install RadioHead
-```
+  ```sh
+  arduino-cli lib install Time
+  arduino-cli lib install RadioHead
+  ```
 
 ### Deploy onto the RP2040
 1. Build the binary `fprime-util generate rpipico && fprime-util build rpipico -j20`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# fprime-proves F' project
+# F´ PROVES
 [![build](https://github.com/proveskit/fprime-proves/actions/workflows/build.yaml/badge.svg)](https://github.com/proveskit/fprime-proves/actions/workflows/build.yaml)
 
-Valid for F' 3.4.3
+F´ (F Prime) flight software for the PROVES CubeSat Kit. This version of the PROVES flight software is under development and is not ready to be used with flight hardware. Please see [proveskit/flight_software](https://github.com/proveskit/flight_software/) for our latest flight ready software.
 
 ## Building and Running the Deployment
+
+Getting started is easy! Please let us know if you run into any issues with the instructions below.
+
+### Check your environment
+You must have Python 3.9+ to build this repo. You can check with `python3 --version`
 
 ### Setup dependencies
 
@@ -33,29 +38,3 @@ Valid for F' 3.4.3
 Run GDS over serial:
 1. `fprime-gds -n --dictionary build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentTopologyAppDictionary.xml --comm-adapter uart --uart-baud 115200 --uart-device /dev/ttyACM0 --output-unframed-data -`
 - Be sure to replace '--uart-device /dev/ttyACM0' to the proper port you connect to the board!
-
-
-## Development Notes:
-- Do NOT use the devel branch! The os layer has been updated and does not sit correctly with the fprime-arduino
-- Do the following BEFORE you make a deployment:
-- Insert fprime-arduino into your project
-- Reference it in your settings.ini
-```
-library_locations: ./fprime-arduino
-default_toolchains: rpipico
-deployment_cookiecutter: https://github.com/fprime-community/fprime-arduino-deployment-cookiecutter.git
-```
-Follow Arduino CLI Installation
-> pip install arduino-cli-cmake-wrapper
-
-> arduino-cli core install rp2040:rp2040
-
-"BroncoDeployment" is currently the only deployment able to run on the Proves RP2040.
-
-
-
-
-
-
-F´ (F Prime) is a component-driven framework that enables rapid development and deployment of spaceflight and other embedded software applications.
-**Please Visit the F´ Website:** https://fprime.jpl.nasa.gov.

--- a/project.cmake
+++ b/project.cmake
@@ -2,8 +2,4 @@
 # This allows for reuse between deployments, or other projects.
 
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components")
-# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/BroncoDeployment/")
-# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/OreDeployment/")
-# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/PROVESDeployment/")
-# add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/UartPROVES/")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/BroncoDeployment/")


### PR DESCRIPTION
This PR:
- archives the dictionary required for using GDS. Satisfying #10 
- removes a few teensy references as a follow up to #1
- uses the fprime-community composite action in our ci build. Follow up to #8, based on [feedback](https://github.com/proveskit/fprime-proves/pull/8#issuecomment-2290704558)
- Fixes readme spacing that causes setup guide to reset count
- Adds to the readme to resolve #4 

<img width="378" alt="Screenshot 2024-08-19 at 23 41 42" src="https://github.com/user-attachments/assets/c6961fd3-435b-441b-b57d-fb5fa7788585">

<img width="246" alt="Screenshot 2024-08-19 at 23 44 32" src="https://github.com/user-attachments/assets/91bc922c-6ac0-41fb-b769-8b5eceba28fe">
