### PR TITLE
Fixed default_toolchain typo

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -8,6 +8,6 @@ default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
 config_dir: ./config
 
 library_locations: ./fprime-arduino
-default_toolchains: rpipico
+default_toolchain: rpipico
 
 deployment_cookiecutter: https://github.com/fprime-community/fprime-arduino-deployment-cookiecutter.git


### PR DESCRIPTION
Building `fprime-proves` for anything other than the `rpipico` target is invalid and will fail. It looks like there was already an attempt to set the default toolchain but there was a typo and it wasn't working.

Here is what the output used to look like when not specifying a toolchain:

```
fprime-util generate
[INFO] Generating build directory at: /Users/nate/code/github.com/proveskit/fprime-proves/build-fprime-automatic-native
...
CMake Error at fprime/cmake/utilities.cmake:586 (message):
-- Configuring incomplete, errors occurred!
  [sub-build] Failed to generate: info-cache:

  CMake Error at Components/Radio/RFM69/CMakeLists.txt:17
  (target_use_arduino_libraries):

    Unknown CMake command "target_use_arduino_libraries".
```

Here's what it looks like now:

```
fprime-util generate
[INFO] Generating build directory at: /Users/nate/code/github.com/proveskit/fprime-proves/build-fprime-automatic-rpipico
...
-- Build files have been written to: /Users/nate/code/github.com/proveskit/fprime-proves/build-fprime-automatic-rpipico
```
