### PR TITLE
README.md change firmware upload instructions so we don't have to push the buttons on the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ git --version
    ```
 
 1. Find your board's mount location
-   > For the next steps you'll need to know where your board is mounted. To find your board's mount location run  `ls -lah /dev/tyy*` for a list of all possible paths. On Linux and WSL your board's mount location will look like `/dev/ttyACM0`. On Mac your board's mount location will look like `/dev/tty.usbmodem101`.
+   > For the next steps you'll need to know where your board is mounted. To find your board's mount location run  `ls -lah /dev/tty*` for a list of all possible paths. On Linux and WSL your board's mount location will look like `/dev/ttyACM0`. On Mac your board's mount location will look like `/dev/tty.usbmodem101`.
 
 1. Upload the firmware to the proves board over USB
    > Don't forget to replace the board mount location after the `-p` flag

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git --version
    ```sh
    pip install -r fprime/requirements.txt
    ```
-2. Install the arduino-cli
+1. Install the arduino-cli
    ```sh
    curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$VIRTUAL_ENV/bin sh
    ```
@@ -96,7 +96,7 @@ git --version
    ```sh
    pip install arduino-cli-cmake-wrapper
    ```
-2. Install the RP2040 board
+1. Install the RP2040 board
     ```sh
     arduino-cli config init
     ```
@@ -106,22 +106,30 @@ git --version
     ```sh
     arduino-cli core install rp2040:rp2040@3.9.5
     ```
-3. Install additional arduino-cli dependencies:
+1. Install additional arduino-cli dependencies:
     ```sh
     arduino-cli lib install Time
     ```
     ```sh
     arduino-cli lib install RadioHead
     ```
+1. Generate the initial fprime build cache
+   ```sh
+   fprime-util generate
+   ```
 
 ### Deploy onto the RP2040
 1. Build the binary
    ```sh
-   fprime-util generate && fprime-util build -j20
+   fprime-util build -j20
    ```
-2. Move the binary from 'build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment' into the Proves board over USB after it has been intialized in boot loader mode (Press both Boot loader and Reset button at the same time). This should reinit the board automatically and will run the deployment.
 
-3. Run GDS over serial:
+1. Upload the firmware to the proves board over USB
+   ```sh
+   arduino-cli upload -v -b 115200 --fqbn rp2040:rp2040:rpipico -p /dev/ttyACM0 -i build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2
+   ```
+
+1. Run GDS over serial:
    ```sh
    fprime-gds -n --dictionary build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentTopologyAppDictionary.xml --comm-adapter uart --uart-baud 115200 --uart-device /dev/ttyACM0 --output-unframed-data -
    ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ git --version
    ```
 
 1. Run GDS over serial:
-   > Don't forget to replace the board mount location after the `--uard-device` flag
+   > Don't forget to replace the board mount location after the `--uart-device` flag
    ```sh
    fprime-gds -n --dictionary build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentTopologyAppDictionary.xml --comm-adapter uart --uart-baud 115200 --uart-device /dev/ttyACM0 --output-unframed-data -
    ```

--- a/README.md
+++ b/README.md
@@ -124,13 +124,17 @@ git --version
    fprime-util build -j20
    ```
 
+1. Find your board's mount location
+   > For the next steps you'll need to know where your board is mounted. To find your board's mount location run  `ls -lah /dev/tyy*` for a list of all possible paths. On Linux and WSL your board's mount location will look like `/dev/ttyACM0`. On Mac your board's mount location will look like `/dev/tty.usbmodem101`.
+
 1. Upload the firmware to the proves board over USB
+   > Don't forget to replace the board mount location after the `-p` flag
    ```sh
    arduino-cli upload -v -b 115200 --fqbn rp2040:rp2040:rpipico -p /dev/ttyACM0 -i build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2
    ```
 
 1. Run GDS over serial:
+   > Don't forget to replace the board mount location after the `--uard-device` flag
    ```sh
    fprime-gds -n --dictionary build-artifacts/rpipico/BroncoDeployment/dict/BroncoDeploymentTopologyAppDictionary.xml --comm-adapter uart --uart-baud 115200 --uart-device /dev/ttyACM0 --output-unframed-data -
    ```
-    > **Note:** Be sure to replace '--uart-device /dev/ttyACM0' to the proper port you connect to the board!


### PR DESCRIPTION
This PR replaces the step where we needed put the board into bootloader mode and drag and drop the uf2 onto the board. The new step uses the arduino cli to do these steps with a single command.

Example:
```sh
arduino-cli upload -v -b 115200 --fqbn rp2040:rp2040:rpipico -p /dev/tty.usbmodem1101 -i build-artifacts/rpipico/BroncoDeployment/bin/BroncoDeployment.uf2
...
Resetting /dev/tty.usbmodem1101
Converting to uf2, output size: 381952, start address: 0x2000
Scanning for RP2040 devices
Flashing /Volumes/RPI-RP2 (RPI-RP2)
Wrote 381952 bytes to /Volumes/RPI-RP2/NEW.UF2
New upload port: /dev/tty.usbmodem1101 (serial)
```